### PR TITLE
Update A0WA6S_1.m

### DIFF
--- a/ZH/A0WA6S_1.m
+++ b/ZH/A0WA6S_1.m
@@ -6,7 +6,7 @@ if n>=9
     %% t es f 
     t = [1:n];
     f = 2*t;
-    for k = 1 : ceil(n/2)-1
+    for k = 1 : ceil(n/2) 
         f(2*k)=-f(2*k);
     end
 


### PR DESCRIPTION
![2020-05-13 16_59_50-MATLAB R2019b - academic use](https://user-images.githubusercontent.com/61527602/81829721-7d899880-953b-11ea-82d7-ea292d1a3e2c.png)

YSOUT0 (Pham Viet Hung), Molnar Andras AASZGM1 csoportjabol:

A ceil(n/2)-1-gyel ha n=ps szam, akkor az az f(n) erteke pozitiv lesz mikozben neativnak kell lennie, mivel pl n=10 eseten k=4-ig fog indexelni az f-ed, viszont a hipotetikus k=5-nek, ami n=10, nem fog negativva valtozni. 
Ez pedig hibas x vektorhoz fog vezetni

Csatoltam egy kepet, amin latni, hogy  ceil(n/2)-1-gyel f(10) = 20, mikozben f(10)=-20 -nak kell lennie